### PR TITLE
separate components

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         additional_dependencies: [toml]
@@ -42,7 +42,7 @@ repos:
         additional_dependencies: [black]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.237"
+    rev: "v0.0.241"
     hooks:
       - id: ruff
         args:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,3 +20,12 @@ Changelog (``cosmology.api``)
      through to the wrapped object. (#8) [nstarman]
 
 - Added ``speed_of_light`` to the constants namespace. (#11) [nstarman]
+
+- Break the standard cosmology into a composition of components: (#25) [nstarman]
+   - DarkEnergyComponent
+   - GlobalCurvatureComponent
+   - PhotonComponent
+   - NeutrinoComponent
+   - MatterComponent
+      - DarkMatterComponent
+      - BaryonComponent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ select = ["ALL"]
 ignore = [
   "ANN101", "ANN102", "ANN401",
   "ARG001", "ARG002",
+  "COM",
   "D105", "D107", "D203", "D213", "D401", "D402",
   "FBT003",
   "N802",
@@ -143,4 +144,4 @@ ignore = [
 "src/cosmology/api/_array_api/*.py" = ["A002", "A003", "D212", "D205", "E501", "N801"]
 "docs/*.py" = ["INP001"]
 "tests/*.py" = ["ANN"]
-"test_*.py" = ["ANN", "D", "N8", "S101"]
+"test_*.py" = ["ANN", "D", "N8", "S101", "TID252"]

--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -7,6 +7,15 @@ from cosmology.api.compat import (
     CosmologyWrapperAPI,
     StandardCosmologyWrapperAPI,
 )
+from cosmology.api.components import (
+    BaryonComponent,
+    DarkEnergyComponent,
+    DarkMatterComponent,
+    GlobalCurvatureComponent,
+    MatterComponent,
+    NeutrinoComponent,
+    PhotonComponent,
+)
 from cosmology.api.constants import CosmologyConstantsAPINamespace
 from cosmology.api.core import CosmologyAPI
 from cosmology.api.namespace import CosmologyAPINamespace
@@ -16,6 +25,14 @@ __all__ = [
     "CosmologyAPI",
     "BackgroundCosmologyAPI",
     "StandardCosmologyAPI",
+    # components
+    "GlobalCurvatureComponent",
+    "MatterComponent",
+    "BaryonComponent",
+    "NeutrinoComponent",
+    "DarkEnergyComponent",
+    "DarkMatterComponent",
+    "PhotonComponent",
     # wrappers
     "CosmologyWrapperAPI",
     "BackgroundCosmologyWrapperAPI",

--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -1,6 +1,5 @@
 """The Cosmology API standard."""
 
-# LOCAL
 from cosmology.api.background import BackgroundCosmologyAPI
 from cosmology.api.compat import (
     BackgroundCosmologyWrapperAPI,

--- a/src/cosmology/api/_array_api/array.py
+++ b/src/cosmology/api/_array_api/array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# STDLIB
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:

--- a/src/cosmology/api/_array_api/dtype.py
+++ b/src/cosmology/api/_array_api/dtype.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# STDLIB
 from typing import Protocol, TypeVar, runtime_checkable
 
 __all__: list[str] = []

--- a/src/cosmology/api/compat/__init__.py
+++ b/src/cosmology/api/compat/__init__.py
@@ -1,6 +1,5 @@
 """The Cosmology API standard for compatability wrappers."""
 
-# LOCAL
 from cosmology.api.compat.background import BackgroundCosmologyWrapperAPI
 from cosmology.api.compat.core import CosmologyWrapperAPI
 from cosmology.api.compat.standard import StandardCosmologyWrapperAPI

--- a/src/cosmology/api/components.py
+++ b/src/cosmology/api/components.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-# STDLIB
 from typing import Protocol
 
 from cosmology.api._array_api import ArrayT

--- a/src/cosmology/api/components.py
+++ b/src/cosmology/api/components.py
@@ -1,0 +1,200 @@
+"""The cosmology API."""
+
+from __future__ import annotations
+
+# STDLIB
+from typing import Protocol
+
+from cosmology.api._array_api import ArrayT
+from cosmology.api.core import CosmologyAPI
+
+__all__ = [
+    "ContainsGlobalCurvature",
+    "ContainsMatter",
+    "ContainsBaryons",
+    "ContainsNeutrinos",
+    "ContainsDarkEnergy",
+    "ContainsColdDarkMatter",
+    "ContainsPhotons",
+]
+
+
+class ContainsGlobalCurvature(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains global curvature, described by :math:`Omega_K`."""
+
+    @property
+    def Ok0(self) -> ArrayT:
+        """Omega curvature; the effective curvature density/critical density at z=0."""
+        ...
+
+    def Ok(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent curvature density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+
+class ContainsMatter(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains matter, described by :math:`Omega_m`."""
+
+    @property
+    def Om0(self) -> ArrayT:
+        """Omega matter; matter density/critical density at z=0."""
+        ...
+
+    def Om(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent non-relativistic matter density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+
+        Notes
+        -----
+        This does not include neutrinos, even if non-relativistic at the
+        redshift of interest; see `Onu`.
+        """
+        ...
+
+
+class ContainsBaryons(ContainsMatter[ArrayT], Protocol):
+    r"""The cosmology contains baryons, described by :math:`Omega_b`."""
+
+    @property
+    def Ob0(self) -> ArrayT:
+        """Omega baryon; baryon density/critical density at z=0."""
+        ...
+
+    def Ob(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent baryon density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+
+class ContainsNeutrinos(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains neutrinos, described by :math:`Omega_\nu`."""
+
+    @property
+    def Onu0(self) -> ArrayT:
+        """Omega nu; the density/critical density of neutrinos at z=0."""
+        ...
+
+    @property
+    def Neff(self) -> ArrayT:
+        """Effective number of neutrino species."""
+        ...
+
+    @property
+    def m_nu(self) -> tuple[ArrayT, ...]:
+        """Neutrino mass in eV."""
+        ...
+
+    def Onu(self, z: ArrayT, /) -> ArrayT:
+        r"""Redshift-dependent neutrino density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+
+class ContainsDarkEnergy(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains photons, described by :math:`Omega_{\rm de}`."""
+
+    @property
+    def Ode0(self) -> ArrayT:
+        """Omega dark energy; dark energy density/critical density at z=0."""
+        ...
+
+    def Ode(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent dark energy density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+
+class ContainsColdDarkMatter(ContainsMatter[ArrayT], Protocol):
+    r"""The cosmology contains cold dark matter, described by :math:`Omega_dm`."""
+
+    @property
+    def Odm0(self) -> ArrayT:
+        """Omega dark matter; dark matter density/critical density at z=0."""
+        ...
+
+    def Odm(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent dark matter density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+
+        Notes
+        -----
+        This does not include neutrinos, even if non-relativistic at the
+        redshift of interest.
+        """
+        ...
+
+
+class ContainsPhotons(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains photons, described by :math:`Omega_\gamma`."""
+
+    @property
+    def Ogamma0(self) -> ArrayT:
+        """Omega gamma; the density/critical density of photons at z=0."""
+        ...
+
+    def Ogamma(self, z: ArrayT, /) -> ArrayT:
+        """Redshift-dependent photon density parameter.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...

--- a/src/cosmology/api/components.py
+++ b/src/cosmology/api/components.py
@@ -8,18 +8,10 @@ from typing import Protocol
 from cosmology.api._array_api import ArrayT
 from cosmology.api.core import CosmologyAPI
 
-__all__ = [
-    "ContainsGlobalCurvature",
-    "ContainsMatter",
-    "ContainsBaryons",
-    "ContainsNeutrinos",
-    "ContainsDarkEnergy",
-    "ContainsColdDarkMatter",
-    "ContainsPhotons",
-]
+__all__: list[str] = []
 
 
-class ContainsGlobalCurvature(CosmologyAPI[ArrayT], Protocol):
+class GlobalCurvatureComponent(CosmologyAPI[ArrayT], Protocol):
     r"""The cosmology contains global curvature, described by :math:`Omega_K`."""
 
     @property
@@ -42,7 +34,7 @@ class ContainsGlobalCurvature(CosmologyAPI[ArrayT], Protocol):
         ...
 
 
-class ContainsMatter(CosmologyAPI[ArrayT], Protocol):
+class MatterComponent(CosmologyAPI[ArrayT], Protocol):
     r"""The cosmology contains matter, described by :math:`Omega_m`."""
 
     @property
@@ -70,7 +62,7 @@ class ContainsMatter(CosmologyAPI[ArrayT], Protocol):
         ...
 
 
-class ContainsBaryons(ContainsMatter[ArrayT], Protocol):
+class BaryonComponent(MatterComponent[ArrayT], Protocol):
     r"""The cosmology contains baryons, described by :math:`Omega_b`."""
 
     @property
@@ -93,7 +85,7 @@ class ContainsBaryons(ContainsMatter[ArrayT], Protocol):
         ...
 
 
-class ContainsNeutrinos(CosmologyAPI[ArrayT], Protocol):
+class NeutrinoComponent(CosmologyAPI[ArrayT], Protocol):
     r"""The cosmology contains neutrinos, described by :math:`Omega_\nu`."""
 
     @property
@@ -126,7 +118,7 @@ class ContainsNeutrinos(CosmologyAPI[ArrayT], Protocol):
         ...
 
 
-class ContainsDarkEnergy(CosmologyAPI[ArrayT], Protocol):
+class DarkEnergyComponent(CosmologyAPI[ArrayT], Protocol):
     r"""The cosmology contains photons, described by :math:`Omega_{\rm de}`."""
 
     @property
@@ -149,7 +141,7 @@ class ContainsDarkEnergy(CosmologyAPI[ArrayT], Protocol):
         ...
 
 
-class ContainsColdDarkMatter(ContainsMatter[ArrayT], Protocol):
+class DarkMatterComponent(MatterComponent[ArrayT], Protocol):
     r"""The cosmology contains cold dark matter, described by :math:`Omega_dm`."""
 
     @property
@@ -177,7 +169,7 @@ class ContainsColdDarkMatter(ContainsMatter[ArrayT], Protocol):
         ...
 
 
-class ContainsPhotons(CosmologyAPI[ArrayT], Protocol):
+class PhotonComponent(CosmologyAPI[ArrayT], Protocol):
     r"""The cosmology contains photons, described by :math:`Omega_\gamma`."""
 
     @property

--- a/src/cosmology/api/constants.py
+++ b/src/cosmology/api/constants.py
@@ -9,7 +9,6 @@ The list of required constants is:
 
 from __future__ import annotations
 
-# STDLIB
 from typing import Any, Protocol, runtime_checkable
 
 __all__: list[str] = []

--- a/src/cosmology/api/core.py
+++ b/src/cosmology/api/core.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-# STDLIB
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from cosmology.api._array_api import ArrayT_co
 
 if TYPE_CHECKING:
-
-    # LOCAL
     from .namespace import CosmologyAPINamespace
 
 __all__: list[str] = []

--- a/src/cosmology/api/namespace.py
+++ b/src/cosmology/api/namespace.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+__all__: list[str] = []
+
 if TYPE_CHECKING:
     from cosmology.api.constants import CosmologyConstantsAPINamespace
-
-__all__: list[str] = []
 
 
 @runtime_checkable

--- a/src/cosmology/api/standard.py
+++ b/src/cosmology/api/standard.py
@@ -11,13 +11,13 @@ from cosmology.api.background import (
     BackgroundCosmologyAPI,
 )
 from cosmology.api.components import (
-    ContainsBaryons,
-    ContainsColdDarkMatter,
-    ContainsDarkEnergy,
-    ContainsGlobalCurvature,
-    ContainsMatter,
-    ContainsNeutrinos,
-    ContainsPhotons,
+    BaryonComponent,
+    DarkEnergyComponent,
+    DarkMatterComponent,
+    GlobalCurvatureComponent,
+    MatterComponent,
+    NeutrinoComponent,
+    PhotonComponent,
 )
 
 __all__: list[str] = []
@@ -63,13 +63,13 @@ STANDARDCOSMO_METHODS = BACKGROUNDCOSMO_METHODS | frozenset(  # TODO: public sco
 
 @runtime_checkable
 class StandardCosmologyAPI(
-    ContainsNeutrinos[ArrayT],
-    ContainsBaryons[ArrayT],
-    ContainsPhotons[ArrayT],
-    ContainsColdDarkMatter[ArrayT],
-    ContainsMatter[ArrayT],
-    ContainsDarkEnergy[ArrayT],
-    ContainsGlobalCurvature[ArrayT],
+    NeutrinoComponent[ArrayT],
+    BaryonComponent[ArrayT],
+    PhotonComponent[ArrayT],
+    DarkMatterComponent[ArrayT],
+    MatterComponent[ArrayT],
+    DarkEnergyComponent[ArrayT],
+    GlobalCurvatureComponent[ArrayT],
     BackgroundCosmologyAPI[ArrayT],
     Protocol,
 ):

--- a/src/cosmology/api/standard.py
+++ b/src/cosmology/api/standard.py
@@ -10,6 +10,15 @@ from cosmology.api.background import (
     BACKGROUNDCOSMO_METHODS,
     BackgroundCosmologyAPI,
 )
+from cosmology.api.components import (
+    ContainsBaryons,
+    ContainsColdDarkMatter,
+    ContainsDarkEnergy,
+    ContainsGlobalCurvature,
+    ContainsMatter,
+    ContainsNeutrinos,
+    ContainsPhotons,
+)
 
 __all__: list[str] = []
 
@@ -53,7 +62,17 @@ STANDARDCOSMO_METHODS = BACKGROUNDCOSMO_METHODS | frozenset(  # TODO: public sco
 
 
 @runtime_checkable
-class StandardCosmologyAPI(BackgroundCosmologyAPI[ArrayT], Protocol):
+class StandardCosmologyAPI(
+    ContainsNeutrinos[ArrayT],
+    ContainsBaryons[ArrayT],
+    ContainsPhotons[ArrayT],
+    ContainsColdDarkMatter[ArrayT],
+    ContainsMatter[ArrayT],
+    ContainsDarkEnergy[ArrayT],
+    ContainsGlobalCurvature[ArrayT],
+    BackgroundCosmologyAPI[ArrayT],
+    Protocol,
+):
     """API Protocol for the standard cosmology and expected set of components.
 
     This is a protocol class that defines the standard API for the standard
@@ -106,54 +125,6 @@ class StandardCosmologyAPI(BackgroundCosmologyAPI[ArrayT], Protocol):
         -------
         Array
         """
-        ...
-
-    @property
-    def Ok0(self) -> ArrayT:
-        """Omega curvature; the effective curvature density/critical density at z=0."""
-        ...
-
-    @property
-    def Om0(self) -> ArrayT:
-        """Omega matter; matter density/critical density at z=0."""
-        ...
-
-    @property
-    def Odm0(self) -> ArrayT:
-        """Omega dark matter; dark matter density/critical density at z=0."""
-        ...
-
-    @property
-    def Ob0(self) -> ArrayT:
-        """Omega baryon; baryon density/critical density at z=0."""
-        ...
-
-    @property
-    def Ode0(self) -> ArrayT:
-        """Omega dark energy; dark energy density/critical density at z=0."""
-        ...
-
-    @property
-    def Ogamma0(self) -> ArrayT:
-        """Omega gamma; the density/critical density of photons at z=0."""
-        ...
-
-    @property
-    def Onu0(self) -> ArrayT:
-        """Omega nu; the density/critical density of neutrinos at z=0."""
-        ...
-
-    # ----------------------------------------------
-    # Neutrinos
-
-    @property
-    def Neff(self) -> ArrayT:
-        """Effective number of neutrino species."""
-        ...
-
-    @property
-    def m_nu(self) -> tuple[ArrayT, ...]:
-        """Neutrino mass in eV."""
         ...
 
     # ==============================================================
@@ -236,114 +207,6 @@ class StandardCosmologyAPI(BackgroundCosmologyAPI[ArrayT], Protocol):
         ----------
         z : Array
             Input redshifts.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def Ok(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent curvature density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def Om(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent non-relativistic matter density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-
-        Notes
-        -----
-        This does not include neutrinos, even if non-relativistic at the
-        redshift of interest; see `Onu`.
-        """
-        ...
-
-    def Ob(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent baryon density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def Odm(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent dark matter density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-
-        Notes
-        -----
-        This does not include neutrinos, even if non-relativistic at the
-        redshift of interest.
-        """
-        ...
-
-    def Ode(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent dark energy density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def Ogamma(self, z: ArrayT, /) -> ArrayT:
-        """Redshift-dependent photon density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def Onu(self, z: ArrayT, /) -> ArrayT:
-        r"""Redshift-dependent neutrino density parameter.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
 
         Returns
         -------

--- a/tests/api/compat/conftest.py
+++ b/tests/api/compat/conftest.py
@@ -1,0 +1,92 @@
+"""Fixtures for the Cosmology API standard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, make_dataclass
+
+import pytest
+from cosmology.api import (
+    BackgroundCosmologyWrapperAPI,
+    CosmologyAPINamespace,
+    CosmologyWrapperAPI,
+    StandardCosmologyWrapperAPI,
+)
+
+from ..conftest import (  # noqa: F401, TID252
+    _return_1arg,
+    _return_one,
+    background_attrs,
+    background_meths,
+    cosmology_ns,
+    standard_attrs,
+    standard_meths,
+)
+
+# ==============================================================================
+# Cosmology API
+
+
+@pytest.fixture(scope="session")
+def cosmology_wrapper_cls(
+    cosmology_ns: CosmologyAPINamespace,  # noqa: F811
+) -> type[CosmologyWrapperAPI]:
+    """An example cosmology API wrapper class."""
+
+    @dataclass(frozen=True)
+    class CosmologyWrapperAPI(CosmologyWrapperAPI):
+        """An example cosmology API wrapper class."""
+
+        cosmo: object
+
+        def __cosmology_namespace__(
+            self, /, *, api_version: str | None = None
+        ) -> CosmologyAPINamespace:
+            return cosmology_ns
+
+        @property
+        def name(self) -> str | None:
+            return None
+
+    return CosmologyWrapperAPI
+
+
+# ==============================================================================
+# BACKGROUND API
+
+
+@pytest.fixture(scope="session")
+def bkg_wrapper_cls(
+    cosmology_wrapper_cls: type[CosmologyWrapperAPI],
+    background_attrs: set[str],  # noqa: F811
+    background_meths: set[str],  # noqa: F811
+) -> type[BackgroundCosmologyWrapperAPI]:
+    """An example FLRW API wrapper class."""
+    return make_dataclass(
+        "FLRWWrapper",
+        [("cosmo", object)],
+        bases=(cosmology_wrapper_cls, BackgroundCosmologyWrapperAPI),
+        namespace={n: property(_return_one) for n in background_attrs}
+        | {n: _return_1arg for n in background_meths},
+        frozen=True,
+    )
+
+
+# ==============================================================================
+# Standard COSMOLOGY API
+
+
+@pytest.fixture(scope="session")
+def standardcosmo_wrapper_cls(
+    bkg_wrapper_cls: type[BackgroundCosmologyWrapperAPI],
+    standard_attrs: set[str],  # noqa: F811
+    standard_meths: set[str],  # noqa: F811
+) -> type[StandardCosmologyWrapperAPI]:
+    """Example FLRW API wrapper class."""
+    return make_dataclass(
+        "FLRWWrapper",
+        [("cosmo", object)],
+        bases=(bkg_wrapper_cls, StandardCosmologyWrapperAPI),
+        namespace={n: property(_return_one) for n in standard_attrs}
+        | {n: _return_1arg for n in standard_meths},
+        frozen=True,
+    )

--- a/tests/api/compat/test_background.py
+++ b/tests/api/compat/test_background.py
@@ -1,16 +1,12 @@
-"""Test ``cosmology_api.api.compat``."""
+"""Test ``cosmology.api.compat``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import dataclass, make_dataclass
 from typing import TYPE_CHECKING
 
-# THIRD-PARTY
 import numpy.array_api as xp
 import pytest
-
-# LOCAL
 from cosmology.api import (
     BackgroundCosmologyAPI,
     BackgroundCosmologyWrapperAPI,
@@ -32,6 +28,7 @@ def test_noncompliant_cosmology_wrapper():
     Test that a non-compliant instance is not a
     `cosmology.api.BackgroundCosmologyWrapperAPI`.
     """
+
     # Simple example: missing everything
     class BackgroundWrapper:
         pass
@@ -99,7 +96,6 @@ class Test_BackgroundCosmologyWrapperAPI:
     ) -> type[BackgroundCosmologyWrapperAPI]:
         @dataclass(frozen=True)
         class BackgroundWrapper(BackgroundCosmologyWrapperAPI):
-
             cosmo: object
 
             def __cosmology_namespace__(

--- a/tests/api/compat/test_core.py
+++ b/tests/api/compat/test_core.py
@@ -1,13 +1,10 @@
-"""Test ``cosmology_api.api.compat``."""
+"""Test ``cosmology.api.compat``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import dataclass
 
 import pytest
-
-# LOCAL
 from cosmology.api import (
     CosmologyAPI,
     CosmologyAPINamespace,
@@ -24,6 +21,7 @@ def test_noncompliant_cosmology_wrapper():
     Test that a non-compliant instance is not a
     `cosmology.api.CosmologyWrapperAPI`.
     """
+
     # Simple example: missing everything
     class ExampleCosmologyWrapper:
         pass
@@ -44,7 +42,6 @@ def test_compliant_cosmology(cosmology_ns):
 
     @dataclass
     class ExampleCosmologyWrapper:
-
         cosmo: object
 
         def __cosmology_namespace__(
@@ -76,7 +73,6 @@ class Test_CosmologyWrapperAPI:
     ) -> type[CosmologyWrapperAPI]:
         @dataclass(frozen=True)
         class ExampleCosmologyWrapper(CosmologyWrapperAPI):
-
             cosmo: object
 
             def __cosmology_namespace__(

--- a/tests/api/compat/test_standard.py
+++ b/tests/api/compat/test_standard.py
@@ -1,16 +1,12 @@
-"""Test ``cosmology_api.api.compat``."""
+"""Test ``cosmology.api.compat``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import dataclass, make_dataclass
 from typing import TYPE_CHECKING
 
-# THIRD-PARTY
 import numpy.array_api as xp
 import pytest
-
-# LOCAL
 from cosmology.api import (
     BackgroundCosmologyAPI,
     BackgroundCosmologyWrapperAPI,
@@ -34,6 +30,7 @@ def test_noncompliant_cosmology_wrapper():
     Test that a non-compliant instance is not a
     `cosmology.api.BackgroundCosmologyWrapperAPI`.
     """
+
     # Simple example: missing everything
     class StandardCosmologyWrapper:
         pass
@@ -103,7 +100,6 @@ class Test_CosmologyWrapperAPI:
     ) -> type[StandardCosmologyWrapperAPI]:
         @dataclass(frozen=True)
         class StandardCosmologyWrapper(StandardCosmologyWrapperAPI):
-
             cosmo: object
 
             def __cosmology_namespace__(

--- a/tests/api/test_background.py
+++ b/tests/api/test_background.py
@@ -1,14 +1,10 @@
-"""Test ``cosmology_api.api.core``."""
+"""Test ``cosmology.api.core``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import field, make_dataclass
 
-# THIRD-PARTY
 import numpy.array_api as xp
-
-# LOCAL
 from cosmology.api import BackgroundCosmologyAPI
 from cosmology.api._array_api import Array
 
@@ -24,10 +20,10 @@ def test_noncompliant_bkg():
     """
     # Simple example: missing everything
 
-    class BackbroundCosmology:
+    class BackgroundCosmology:
         pass
 
-    cosmo = BackbroundCosmology()
+    cosmo = BackgroundCosmology()
 
     assert not isinstance(cosmo, BackgroundCosmologyAPI)
 
@@ -49,18 +45,18 @@ def test_compliant_bkg(cosmology_cls, background_attrs, background_meths):
     def _return_1arg(self, z: Array, /) -> Array:
         return z
 
-    fields = ()
+    flds = set()
 
     BackgroundCosmology = make_dataclass(
         "BackgroundCosmology",
-        [(n, Array, field(default_factory=_default_one)) for n in fields],
+        [(n, Array, field(default_factory=_default_one)) for n in flds],
         bases=(cosmology_cls,),
-        namespace={n: property(_return_one) for n in background_attrs - set(fields)}
+        namespace={n: property(_return_one) for n in background_attrs - set(flds)}
         | {n: _return_1arg for n in background_meths},
         frozen=True,
     )
 
-    cosmo = BackgroundCosmology()
+    cosmo = BackgroundCosmology(name=None)
 
     assert isinstance(cosmo, BackgroundCosmologyAPI)
 

--- a/tests/api/test_components/__init__.py
+++ b/tests/api/test_components/__init__.py
@@ -1,0 +1,1 @@
+"""Test the Cosmology API standard."""

--- a/tests/api/test_components/test_baryon.py
+++ b/tests/api/test_components/test_baryon.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.BaryonComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import BaryonComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_baryoncomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.BaryonComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleBaryonComponent:
+        pass
+
+    cosmo = ExampleBaryonComponent()
+
+    assert not isinstance(cosmo, BaryonComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_baryoncomponent(matter_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.BaryonComponent`.
+    """
+    ExampleBaryonComponent = make_dataclass(
+        "ExampleBaryonComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {"Ob0"}],
+        bases=(matter_cls,),
+        namespace={"Ob": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleBaryonComponent()
+
+    assert isinstance(cosmo, BaryonComponent)
+
+
+def test_fixture(baryon_cls):
+    """
+    Test that the ``baryon_cls`` fixture is a
+    `cosmology.api.BaryonComponent`.
+    """
+    assert isinstance(baryon_cls(), BaryonComponent)

--- a/tests/api/test_components/test_darkenergy.py
+++ b/tests/api/test_components/test_darkenergy.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.DarkEnergyComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import DarkEnergyComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg, _return_one  # noqa: F401
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_darkenergycomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.DarkEnergyComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleDarkEnergyComponent:
+        pass
+
+    cosmo = ExampleDarkEnergyComponent()
+
+    assert not isinstance(cosmo, DarkEnergyComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_darkenergycomponent(bkg_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.DarkEnergyComponent`.
+    """
+    ExampleDarkEnergyComponent = make_dataclass(
+        "ExampleDarkEnergyComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {"Ode0"}],
+        bases=(bkg_cls,),
+        namespace={"Ode": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleDarkEnergyComponent()
+
+    assert isinstance(cosmo, DarkEnergyComponent)
+
+
+def test_fixture(darkenergy_cls):
+    """
+    Test that the ``darkenergy_cls`` fixture is a
+    `cosmology.api.DarkEnergyComponent`.
+    """
+    assert isinstance(darkenergy_cls(), DarkEnergyComponent)

--- a/tests/api/test_components/test_darkmatter.py
+++ b/tests/api/test_components/test_darkmatter.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.DarkMatterComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import DarkMatterComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg, _return_one
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_darkmattercomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.DarkMatterComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleDarkMatterComponent:
+        pass
+
+    cosmo = ExampleDarkMatterComponent()
+
+    assert not isinstance(cosmo, DarkMatterComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_darkmattercomponent(matter_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.DarkMatterComponent`.
+    """
+    ExampleDarkMatterComponent = make_dataclass(
+        "ExampleDarkMatterComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {}],
+        bases=(matter_cls,),
+        namespace={"Odm0": _return_one, "Odm": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleDarkMatterComponent()
+
+    assert isinstance(cosmo, DarkMatterComponent)
+
+
+def test_fixture(darkmatter_cls):
+    """
+    Test that the ``darkmatter_cls`` fixture is a
+    `cosmology.api.DarkMatterComponent`.
+    """
+    assert isinstance(darkmatter_cls(), DarkMatterComponent)

--- a/tests/api/test_components/test_globalcurvature.py
+++ b/tests/api/test_components/test_globalcurvature.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.GlobalCurvatureComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import GlobalCurvatureComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg, _return_one
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_globalcurvaturecomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.GlobalCurvatureComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleGlobalCurvatureComponent:
+        pass
+
+    cosmo = ExampleGlobalCurvatureComponent()
+
+    assert not isinstance(cosmo, GlobalCurvatureComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_globalcurvaturecomponent(bkg_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.GlobalCurvatureComponent`.
+    """
+    ExampleGlobalCurvatureComponent = make_dataclass(
+        "ExampleGlobalCurvatureComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {}],
+        bases=(bkg_cls,),
+        namespace={"Ok0": _return_one, "Ok": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleGlobalCurvatureComponent()
+
+    assert isinstance(cosmo, GlobalCurvatureComponent)
+
+
+def test_fixture(globalcurvature_cls):
+    """
+    Test that the ``globalcurvature_cls`` fixture is a
+    `cosmology.api.GlobalCurvatureComponent`.
+    """
+    assert isinstance(globalcurvature_cls(), GlobalCurvatureComponent)

--- a/tests/api/test_components/test_matter.py
+++ b/tests/api/test_components/test_matter.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.MatterComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import MatterComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_mattercomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.MatterComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleMatterComponent:
+        pass
+
+    cosmo = ExampleMatterComponent()
+
+    assert not isinstance(cosmo, MatterComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_mattercomponent(bkg_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.MatterComponent`.
+    """
+    ExampleMatterComponent = make_dataclass(
+        "ExampleMatterComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {"Om0"}],
+        bases=(bkg_cls,),
+        namespace={"Om": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleMatterComponent()
+
+    assert isinstance(cosmo, MatterComponent)
+
+
+def test_fixture(matter_cls):
+    """
+    Test that the ``matter_cls`` fixture is a
+    `cosmology.api.MatterComponent`.
+    """
+    assert isinstance(matter_cls(), MatterComponent)

--- a/tests/api/test_components/test_neutrino.py
+++ b/tests/api/test_components/test_neutrino.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.NeutrinoComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import NeutrinoComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg, _return_one
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_neutrinocomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.NeutrinoComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExampleNeutrinoComponent:
+        pass
+
+    cosmo = ExampleNeutrinoComponent()
+
+    assert not isinstance(cosmo, NeutrinoComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_neutrinocomponent(bkg_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.NeutrinoComponent`.
+    """
+    ExampleNeutrinoComponent = make_dataclass(
+        "ExampleNeutrinoComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {"Neff", "m_nu"}],
+        bases=(bkg_cls,),
+        namespace={"Onu0": _return_one, "Onu": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExampleNeutrinoComponent()
+
+    assert isinstance(cosmo, NeutrinoComponent)
+
+
+def test_fixture(neutrino_cls):
+    """
+    Test that the ``neutrino_cls`` fixture is a
+    `cosmology.api.NeutrinoComponent`.
+    """
+    assert isinstance(neutrino_cls(), NeutrinoComponent)

--- a/tests/api/test_components/test_photon.py
+++ b/tests/api/test_components/test_photon.py
@@ -1,0 +1,57 @@
+"""Test ``cosmology.api.PhotonComponent``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import PhotonComponent
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg, _return_one
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_photoncomponent():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.PhotonComponent`.
+    """
+    # Simple example: missing everything
+
+    class ExamplePhotonComponent:
+        pass
+
+    cosmo = ExamplePhotonComponent()
+
+    assert not isinstance(cosmo, PhotonComponent)
+
+    # TODO: more examples?
+
+
+def test_compliant_photoncomponent(bkg_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.PhotonComponent`.
+    """
+    ExamplePhotonComponent = make_dataclass(
+        "ExamplePhotonComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in {}],
+        bases=(bkg_cls,),
+        namespace={"Ogamma0": _return_one, "Ogamma": _return_1arg},
+        frozen=True,
+    )
+
+    cosmo = ExamplePhotonComponent()
+
+    assert isinstance(cosmo, PhotonComponent)
+
+
+def test_fixture(photon_cls):
+    """
+    Test that the ``photon_cls`` fixture is a
+    `cosmology.api.PhotonComponent`.
+    """
+    assert isinstance(photon_cls(), PhotonComponent)

--- a/tests/api/test_constants.py
+++ b/tests/api/test_constants.py
@@ -1,9 +1,7 @@
-"""Test ``cosmology_api.api.constants``."""
+"""Test ``cosmology.api.constants``."""
 
-# STDLIB
 from types import SimpleNamespace
 
-# LOCAL
 from cosmology.api import CosmologyConstantsAPINamespace
 
 ################################################################################

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -1,11 +1,9 @@
-"""Test ``cosmology_api.api.core``."""
+"""Test ``cosmology.api.core``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import dataclass
 
-# LOCAL
 from cosmology.api import CosmologyAPI, CosmologyAPINamespace
 
 ################################################################################

--- a/tests/api/test_namespace.py
+++ b/tests/api/test_namespace.py
@@ -1,9 +1,7 @@
-"""Test ``cosmology_api.api.namespace``."""
+"""Test ``cosmology.api.namespace``."""
 
-# STDLIB
 from types import SimpleNamespace
 
-# LOCAL
 from cosmology.api import CosmologyAPINamespace
 
 ################################################################################

--- a/tests/api/test_standard.py
+++ b/tests/api/test_standard.py
@@ -1,16 +1,24 @@
-"""Test ``cosmology_api.api.core``."""
+"""Test ``cosmology.api.core``."""
 
 from __future__ import annotations
 
-# STDLIB
 from dataclasses import field, make_dataclass
 
-# THIRD-PARTY
-import numpy.array_api as xp
-
-# LOCAL
 from cosmology.api import StandardCosmologyAPI
 from cosmology.api._array_api import Array
+from cosmology.api.background import BackgroundCosmologyAPI
+from cosmology.api.components import (
+    BaryonComponent,
+    DarkEnergyComponent,
+    DarkMatterComponent,
+    GlobalCurvatureComponent,
+    MatterComponent,
+    NeutrinoComponent,
+    PhotonComponent,
+)
+from cosmology.api.core import CosmologyAPI
+
+from .conftest import _default_one, _return_1arg, _return_one
 
 ################################################################################
 # TESTS
@@ -39,16 +47,6 @@ def test_compliant_bkg(cosmology_cls, standard_attrs, standard_meths):
     Test that an instance is `cosmology.api.StandardCosmologyAPI` even if it
     doesn't inherit from `cosmology.api.StandardCosmologyAPI`.
     """
-
-    def _default_one() -> Array:
-        return xp.ones((), dtype=xp.int32)
-
-    def _return_one(self, /) -> Array:
-        return _default_one()
-
-    def _return_1arg(self, z: Array, /) -> Array:
-        return z
-
     fields = ("H0", "Om0", "Ode0", "Tcmb0", "Neff", "m_nu", "Ob0")
 
     StandardCosmology = make_dataclass(
@@ -62,6 +60,20 @@ def test_compliant_bkg(cosmology_cls, standard_attrs, standard_meths):
 
     cosmo = StandardCosmology()
 
+    # Check Base and Background
+    assert isinstance(cosmo, CosmologyAPI)
+    assert isinstance(cosmo, BackgroundCosmologyAPI)
+
+    # Check Components
+    assert isinstance(cosmo, BaryonComponent)
+    assert isinstance(cosmo, DarkEnergyComponent)
+    assert isinstance(cosmo, DarkMatterComponent)
+    assert isinstance(cosmo, GlobalCurvatureComponent)
+    assert isinstance(cosmo, MatterComponent)
+    assert isinstance(cosmo, NeutrinoComponent)
+    assert isinstance(cosmo, PhotonComponent)
+
+    # Full Standard Cosmology
     assert isinstance(cosmo, StandardCosmologyAPI)
 
 


### PR DESCRIPTION
Signed-off-by: nstarman <nstarkman@protonmail.com>

Separate components to the standard cosmology.
This allows quick building and checking of a cosmology class / API that only has a set of components.


## PR Checklist

- [x] Give a detailed description of the PR above.
- [x] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
