### PR TITLE
Hubble parametrized

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.254"
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
@@ -43,13 +50,6 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black]
-
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.254"
-    hooks:
-      - id: ruff
-        args:
-          - --fix
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.0.1"

--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -12,13 +12,13 @@ from cosmology.api._components import (
 )
 from cosmology.api._constants import CosmologyConstantsAPINamespace
 from cosmology.api._core import CosmologyAPI
+from cosmology.api._extras import HasHubbleParameter
 from cosmology.api._namespace import CosmologyAPINamespace
 from cosmology.api._standard import StandardCosmologyAPI
 from cosmology.api.compat import (
     CosmologyWrapperAPI,
     StandardCosmologyWrapperAPI,
 )
-from cosmology.api.extras import HasHubbleParameter
 
 __all__ = [
     "CosmologyAPI",

--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -18,6 +18,7 @@ from cosmology.api.compat import (
     CosmologyWrapperAPI,
     StandardCosmologyWrapperAPI,
 )
+from cosmology.api.extras import HasHubbleParameter
 
 __all__ = [
     "CosmologyAPI",
@@ -31,6 +32,8 @@ __all__ = [
     "DarkEnergyComponent",
     "DarkMatterComponent",
     "PhotonComponent",
+    # parametrizations
+    "HasHubbleParameter",
     # wrappers
     "CosmologyWrapperAPI",
     "StandardCosmologyWrapperAPI",

--- a/src/cosmology/api/_extras.py
+++ b/src/cosmology/api/_extras.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from cosmology.api._array_api import ArrayT
-from cosmology.api.core import CosmologyAPI
+from cosmology.api._core import CosmologyAPI
 
 __all__: list[str] = []
 

--- a/src/cosmology/api/_extras.py
+++ b/src/cosmology/api/_extras.py
@@ -15,12 +15,7 @@ class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
 
     @property
     def H0(self) -> ArrayT:
-        """Hubble function at redshift 0 in km s-1 Mpc-1."""
-        ...
-
-    @property
-    def h(self) -> ArrayT:
-        r"""Dimensionless Hubble parameter, h = H_0 / (100 [km/sec/Mpc])."""
+        """Hubble parameter at redshift 0 in km s-1 Mpc-1."""
         ...
 
     @property
@@ -34,7 +29,7 @@ class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
         ...
 
     def H(self, z: ArrayT | float, /) -> ArrayT:
-        """Hubble function :math:`H(z)` in km s-1 Mpc-1.
+        """Hubble parameter :math:`H(z)` in km s-1 Mpc-1.
 
         Parameters
         ----------
@@ -47,13 +42,13 @@ class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
         """
         ...
 
-    def efunc(self, z: ArrayT | float, /) -> ArrayT:
+    def h_over_h0(self, z: ArrayT | float, /) -> ArrayT:
         """Standardised Hubble function :math:`E(z) = H(z)/H_0`.
 
         Parameters
         ----------
         z : Array
-            The redshift(s) at which to evaluate efunc.
+            The redshift(s) at which to evaluate.
 
         Returns
         -------

--- a/src/cosmology/api/_extras.py
+++ b/src/cosmology/api/_extras.py
@@ -60,17 +60,3 @@ class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
         Array
         """
         ...
-
-    def inv_efunc(self, z: ArrayT | float, /) -> ArrayT:
-        """Inverse of ``efunc``.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...

--- a/src/cosmology/api/_extras.py
+++ b/src/cosmology/api/_extras.py
@@ -11,7 +11,7 @@ __all__: list[str] = []
 
 
 class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
-    r"""The cosmology contains global curvature, described by :math:`Omega_K`."""
+    r"""The cosmology has methods to retrieve the Hubble parameter :math:`H`."""
 
     @property
     def H0(self) -> ArrayT:

--- a/src/cosmology/api/_standard.py
+++ b/src/cosmology/api/_standard.py
@@ -15,7 +15,7 @@ from cosmology.api._components import (
     NeutrinoComponent,
     PhotonComponent,
 )
-from cosmology.api.extras import HasHubbleParameter
+from cosmology.api._extras import HasHubbleParameter
 
 __all__: list[str] = []
 

--- a/src/cosmology/api/_standard.py
+++ b/src/cosmology/api/_standard.py
@@ -15,6 +15,7 @@ from cosmology.api._components import (
     NeutrinoComponent,
     PhotonComponent,
 )
+from cosmology.api.extras import HasHubbleParameter
 
 __all__: list[str] = []
 
@@ -28,6 +29,7 @@ class StandardCosmologyAPI(
     MatterComponent[ArrayT],
     DarkEnergyComponent[ArrayT],
     GlobalCurvatureComponent[ArrayT],
+    HasHubbleParameter[ArrayT],
     FriedmannLemaitreRobertsonWalker[ArrayT],
     Protocol,
 ):
@@ -42,29 +44,6 @@ class StandardCosmologyAPI(
     @property
     def Tcmb0(self) -> ArrayT:
         """Temperature of the CMB at redshift 0 in Kelvin."""
-        ...
-
-    # ----------------------------------------------
-    # Hubble
-
-    @property
-    def H0(self) -> ArrayT:
-        """Hubble function at redshift 0 in km s-1 Mpc-1."""
-        ...
-
-    @property
-    def h(self) -> ArrayT:
-        r"""Dimensionless Hubble parameter, h = H_0 / (100 [km/sec/Mpc])."""
-        ...
-
-    @property
-    def hubble_distance(self) -> ArrayT:
-        """Hubble distance in Mpc."""
-        ...
-
-    @property
-    def hubble_time(self) -> ArrayT:
-        """Hubble time in Gyr."""
         ...
 
     # ----------------------------------------------
@@ -101,54 +80,6 @@ class StandardCosmologyAPI(
         Array
         """
         ...
-
-    # ----------------------------------------------
-    # Hubble
-
-    def H(self, z: ArrayT | float, /) -> ArrayT:
-        """Hubble function :math:`H(z)` in km s-1 Mpc-1.
-
-        Parameters
-        ----------
-        z : Array
-            The redshift(s) at which to evaluate the Hubble parameter.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def efunc(self, z: ArrayT | float, /) -> ArrayT:
-        """Standardised Hubble function :math:`E(z) = H(z)/H_0`.
-
-        Parameters
-        ----------
-        z : Array
-            The redshift(s) at which to evaluate efunc.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    def inv_efunc(self, z: ArrayT | float, /) -> ArrayT:
-        """Inverse of ``efunc``.
-
-        Parameters
-        ----------
-        z : Array, positional-only
-            Input redshift.
-
-        Returns
-        -------
-        Array
-        """
-        ...
-
-    # ----------------------------------------------
-    # Omega
 
     def Otot(self, z: ArrayT | float, /) -> ArrayT:
         r"""Redshift-dependent total density parameter.

--- a/src/cosmology/api/extras.py
+++ b/src/cosmology/api/extras.py
@@ -1,0 +1,76 @@
+"""The cosmology API."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from cosmology.api._array_api import ArrayT
+from cosmology.api.core import CosmologyAPI
+
+__all__: list[str] = []
+
+
+class HasHubbleParameter(CosmologyAPI[ArrayT], Protocol):
+    r"""The cosmology contains global curvature, described by :math:`Omega_K`."""
+
+    @property
+    def H0(self) -> ArrayT:
+        """Hubble function at redshift 0 in km s-1 Mpc-1."""
+        ...
+
+    @property
+    def h(self) -> ArrayT:
+        r"""Dimensionless Hubble parameter, h = H_0 / (100 [km/sec/Mpc])."""
+        ...
+
+    @property
+    def hubble_distance(self) -> ArrayT:
+        """Hubble distance in Mpc."""
+        ...
+
+    @property
+    def hubble_time(self) -> ArrayT:
+        """Hubble time in Gyr."""
+        ...
+
+    def H(self, z: ArrayT | float, /) -> ArrayT:
+        """Hubble function :math:`H(z)` in km s-1 Mpc-1.
+
+        Parameters
+        ----------
+        z : Array
+            The redshift(s) at which to evaluate the Hubble parameter.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+    def efunc(self, z: ArrayT | float, /) -> ArrayT:
+        """Standardised Hubble function :math:`E(z) = H(z)/H_0`.
+
+        Parameters
+        ----------
+        z : Array
+            The redshift(s) at which to evaluate efunc.
+
+        Returns
+        -------
+        Array
+        """
+        ...
+
+    def inv_efunc(self, z: ArrayT | float, /) -> ArrayT:
+        """Inverse of ``efunc``.
+
+        Parameters
+        ----------
+        z : Array, positional-only
+            Input redshift.
+
+        Returns
+        -------
+        Array
+        """
+        ...

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,6 +25,7 @@ from cosmology.api import (
     StandardCosmologyAPI,
 )
 from cosmology.api._array_api import Array
+from cosmology.api.extras import HasHubbleParameter
 
 CT = TypeVar("CT", bound=CosmologyAPI)
 
@@ -210,7 +211,6 @@ def neutrino_cls(
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.parametrize("comp_cls", [PhotonComponent])
 def photon_cls(
     cosmology_cls: type[CosmologyAPI],
 ) -> type[PhotonComponent | CosmologyAPI]:
@@ -239,6 +239,28 @@ def darkenergy_cls(
     fields = {"Ode0"}
     return make_dataclass(
         "ExampleDarkEnergyComponent",
+        [(n, Array, field(default_factory=_default_one)) for n in fields],
+        bases=(cosmology_cls,),
+        namespace={n: property(_return_one) for n in comp_attrs - set(fields)}
+        | {n: _return_1arg for n in comp_meths},
+        frozen=True,
+    )
+
+
+# ==============================================================================
+# Parametrizations API
+
+
+@pytest.fixture(scope="session")
+def hashubbleparamet_cls(
+    cosmology_cls: type[CosmologyAPI],
+) -> type[HasHubbleParameter | CosmologyAPI]:
+    """An example standard cosmology API class."""
+    comp_attrs = get_comp_attrs(HasHubbleParameter)
+    comp_meths = get_comp_meths(HasHubbleParameter)
+    fields = {"H0"}
+    return make_dataclass(
+        "ExampleHasHubbleParameter",
         [(n, Array, field(default_factory=_default_one)) for n in fields],
         bases=(cosmology_cls,),
         namespace={n: property(_return_one) for n in comp_attrs - set(fields)}

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,7 +25,7 @@ from cosmology.api import (
     StandardCosmologyAPI,
 )
 from cosmology.api._array_api import Array
-from cosmology.api.extras import HasHubbleParameter
+from cosmology.api._extras import HasHubbleParameter
 
 CT = TypeVar("CT", bound=CosmologyAPI)
 

--- a/tests/api/test_extras/__init__.py
+++ b/tests/api/test_extras/__init__.py
@@ -1,0 +1,1 @@
+"""Test the Cosmology API standard."""

--- a/tests/api/test_extras/test_hubble.py
+++ b/tests/api/test_extras/test_hubble.py
@@ -1,0 +1,64 @@
+"""Test ``cosmology.api.HasHubbleParameter``."""
+
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+
+from cosmology.api import HasHubbleParameter
+from cosmology.api._array_api import Array
+
+from ..conftest import _default_one, _return_1arg
+
+################################################################################
+# TESTS
+################################################################################
+
+
+def test_noncompliant_hubbleparametrized():
+    """
+    Test that a non-compliant instance is not a
+    `cosmology.api.HasHubbleParameter`.
+    """
+    # Simple example: missing everything
+
+    class ExampleHasHubbleParameter:
+        pass
+
+    cosmo = ExampleHasHubbleParameter()
+
+    assert not isinstance(cosmo, HasHubbleParameter)
+
+    # TODO: more examples?
+
+
+def test_compliant_hubbleparametrized(hashubbleparamet_cls):
+    """
+    Test that a compliant instance is a
+    `cosmology.api.HasHubbleParameter`.
+    """
+    ExampleHasHubbleParameter = make_dataclass(
+        "ExampleHasHubbleParameter",
+        [(n, Array, field(default_factory=_default_one)) for n in {"H0"}],
+        bases=(hashubbleparamet_cls,),
+        namespace={
+            "h": _default_one,
+            "hubble_time": _default_one,
+            "hubble_distance": _default_one,
+            "H": _return_1arg,
+            "efunc": _return_1arg,
+            "inv_efunc": _return_1arg,
+        },
+        frozen=True,
+    )
+
+    cosmo = ExampleHasHubbleParameter()
+
+    assert isinstance(cosmo, HasHubbleParameter)
+
+
+def test_fixture(hashubbleparamet_cls):
+    """
+    Test that the ``hashubbleparamet_cls`` fixture is a
+    `cosmology.api.HasHubbleParameter`.
+    """
+    assert isinstance(hashubbleparamet_cls(), HasHubbleParameter)

--- a/tests/api/test_standard.py
+++ b/tests/api/test_standard.py
@@ -17,7 +17,7 @@ from cosmology.api._components import (
     PhotonComponent,
 )
 from cosmology.api._core import CosmologyAPI
-from cosmology.api.extras import HasHubbleParameter
+from cosmology.api._extras import HasHubbleParameter
 
 from .conftest import _default_one, _return_1arg, _return_one
 

--- a/tests/api/test_standard.py
+++ b/tests/api/test_standard.py
@@ -17,6 +17,7 @@ from cosmology.api._components import (
     PhotonComponent,
 )
 from cosmology.api._core import CosmologyAPI
+from cosmology.api.extras import HasHubbleParameter
 
 from .conftest import _default_one, _return_1arg, _return_one
 
@@ -25,7 +26,7 @@ from .conftest import _default_one, _return_1arg, _return_one
 ################################################################################
 
 
-def test_noncompliant_cosmo():
+def test_noncompliant_standard():
     """
     Test that a non-compliant instance is not a
     `cosmology.api.CosmologyAPI`.
@@ -42,7 +43,7 @@ def test_noncompliant_cosmo():
     # TODO: more examples?
 
 
-def test_compliant_cosmo(cosmology_cls, standard_attrs, standard_meths):
+def test_compliant_standard(cosmology_cls, standard_attrs, standard_meths):
     """
     Test that an instance is `cosmology.api.StandardCosmologyAPI` even if it
     doesn't inherit from `cosmology.api.StandardCosmologyAPI`.
@@ -72,6 +73,9 @@ def test_compliant_cosmo(cosmology_cls, standard_attrs, standard_meths):
     assert isinstance(cosmo, MatterComponent)
     assert isinstance(cosmo, NeutrinoComponent)
     assert isinstance(cosmo, PhotonComponent)
+
+    # Check Parametrizations
+    assert isinstance(cosmo, HasHubbleParameter)
 
     # Full Standard Cosmology
     assert isinstance(cosmo, StandardCosmologyAPI)


### PR DESCRIPTION
I think the `StandardCosmology` should only be an inheritance of other components. Therefore, we should separate out the Hubble (and later the Tcmb) pieces. This PR makes the Protocol ``HubbleParametrized`` which holds the Hubble info.

## PR Checklist

- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
