### PR TITLE
remove API from StandardCosmology name

### DIFF
--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -14,7 +14,7 @@ from cosmology.api._constants import CosmologyConstantsAPINamespace
 from cosmology.api._core import CosmologyAPI
 from cosmology.api._extras import HasHubbleParameter, HasTcmb
 from cosmology.api._namespace import CosmologyAPINamespace
-from cosmology.api._standard import StandardCosmologyAPI
+from cosmology.api._standard import StandardCosmology
 from cosmology.api.compat import (
     CosmologyWrapperAPI,
     StandardCosmologyWrapperAPI,
@@ -23,7 +23,7 @@ from cosmology.api.compat import (
 __all__ = [
     "CosmologyAPI",
     "FriedmannLemaitreRobertsonWalker",
-    "StandardCosmologyAPI",
+    "StandardCosmology",
     # components
     "HasGlobalCurvatureComponent",
     "HasMatterComponent",

--- a/src/cosmology/api/_background.py
+++ b/src/cosmology/api/_background.py
@@ -21,7 +21,7 @@ class FriedmannLemaitreRobertsonWalker(CosmologyAPI[ArrayT], Protocol):
 
     See Also
     --------
-    StandardCosmologyAPI
+    StandardCosmology
         The standard cosmology API, with the expected set of components: matter,
         radiation, neutrinos, dark matter, and dark energy.
     """

--- a/src/cosmology/api/_standard.py
+++ b/src/cosmology/api/_standard.py
@@ -21,7 +21,7 @@ __all__: list[str] = []
 
 
 @runtime_checkable
-class StandardCosmologyAPI(
+class StandardCosmology(
     HasNeutrinoComponent[ArrayT],
     HasBaryonComponent[ArrayT],
     HasPhotonComponent[ArrayT],

--- a/src/cosmology/api/compat/_standard.py
+++ b/src/cosmology/api/compat/_standard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from cosmology.api._array_api import ArrayT
-from cosmology.api._standard import StandardCosmologyAPI
+from cosmology.api._standard import StandardCosmology
 from cosmology.api.compat._core import CosmologyWrapperAPI
 
 __all__: list[str] = []
@@ -13,10 +13,10 @@ __all__: list[str] = []
 
 class StandardCosmologyWrapperAPI(
     CosmologyWrapperAPI[ArrayT],
-    StandardCosmologyAPI[ArrayT],
+    StandardCosmology[ArrayT],
     Protocol,
 ):
-    """The standard for ``StandardCosmologyAPI`` compatability wrappers.
+    """The standard for ``StandardCosmology`` compatability wrappers.
 
     This is a protocol class that defines an API standard. It is not intended to
     be used directly, and should not be instantiated. Instead, it should be used

--- a/tests/api/compat/test_standard.py
+++ b/tests/api/compat/test_standard.py
@@ -11,7 +11,7 @@ from cosmology.api import (
     CosmologyAPI,
     CosmologyAPINamespace,
     CosmologyWrapperAPI,
-    StandardCosmologyAPI,
+    StandardCosmology,
     StandardCosmologyWrapperAPI,
 )
 
@@ -84,7 +84,7 @@ def test_compliant_bkg_wrapper(cosmology_ns, standard_attrs, standard_meths):
 
     assert isinstance(wrapper, CosmologyAPI)
     assert isinstance(wrapper, CosmologyWrapperAPI)
-    assert isinstance(wrapper, StandardCosmologyAPI)
+    assert isinstance(wrapper, StandardCosmology)
     assert isinstance(wrapper, StandardCosmologyWrapperAPI)
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -22,7 +22,7 @@ from cosmology.api import (
     HasMatterComponent,
     HasNeutrinoComponent,
     HasPhotonComponent,
-    StandardCosmologyAPI,
+    StandardCosmology,
 )
 from cosmology.api._array_api import Array
 from cosmology.api._extras import HasHubbleParameter, HasTcmb
@@ -340,21 +340,19 @@ def bkg_flrw(
 # Standard API
 
 
-STANDARDCOSMO_ATTRS, STANDARDCOSMO_METHS = _get_attrs_meths(
-    StandardCosmologyAPI, CosmologyAPI
-)
+STDCOSMO_ATTRS, STDCOSMO_METHS = _get_attrs_meths(StandardCosmology, CosmologyAPI)
 
 
 @pytest.fixture(scope="session")
 def standard_attrs() -> frozenset[str]:
     """The Standard FLRW API atributes."""
-    return STANDARDCOSMO_ATTRS
+    return STDCOSMO_ATTRS
 
 
 @pytest.fixture(scope="session")
 def standard_meths() -> frozenset[str]:
     """The Standard FLRW API methods."""
-    return STANDARDCOSMO_METHS
+    return STDCOSMO_METHS
 
 
 @pytest.fixture(scope="session")
@@ -369,7 +367,7 @@ def standard_cls(  # noqa: PLR0913
     darkenergy_cls: type[HasDarkEnergyComponent],
     standard_attrs: set[str],
     standard_meths: set[str],
-) -> type[StandardCosmologyAPI]:
+) -> type[StandardCosmology]:
     """Example FLRW API class."""
     bases = (
         neutrino_cls,
@@ -397,7 +395,7 @@ def standard_cls(  # noqa: PLR0913
 
 @pytest.fixture(scope="session")
 def standardcosmo(
-    standard_cls: type[StandardCosmologyAPI],
-) -> StandardCosmologyAPI:
+    standard_cls: type[StandardCosmology],
+) -> StandardCosmology:
     """Example FLRW API instance."""
     return standard_cls()

--- a/tests/api/test_standard.py
+++ b/tests/api/test_standard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import field, make_dataclass
 
-from cosmology.api import StandardCosmologyAPI
+from cosmology.api import StandardCosmology
 from cosmology.api._array_api import Array
 from cosmology.api._background import FriedmannLemaitreRobertsonWalker
 from cosmology.api._components import (
@@ -33,25 +33,25 @@ def test_noncompliant_standard():
     """
     # Simple example: missing everything
 
-    class StandardCosmology:
+    class NonStandardCosmology:
         pass
 
-    cosmo = StandardCosmology()
+    cosmo = NonStandardCosmology()
 
-    assert not isinstance(cosmo, StandardCosmologyAPI)
+    assert not isinstance(cosmo, StandardCosmology)
 
     # TODO: more examples?
 
 
 def test_compliant_standard(cosmology_cls, standard_attrs, standard_meths):
     """
-    Test that an instance is `cosmology.api.StandardCosmologyAPI` even if it
-    doesn't inherit from `cosmology.api.StandardCosmologyAPI`.
+    Test that an instance is `cosmology.api.StandardCosmology` even if it
+    doesn't inherit from `cosmology.api.StandardCosmology`.
     """
     fields = ("H0", "Omega_m0", "Omega_de0", "Tcmb0", "Neff", "m_nu", "Omega_b0")
 
-    StandardCosmology = make_dataclass(
-        "StandardCosmology",
+    ExampleStandardCosmology = make_dataclass(
+        "ExampleStandardCosmology",
         [(n, Array, field(default_factory=_default_one)) for n in fields],
         bases=(cosmology_cls,),
         namespace={n: property(_return_one) for n in standard_attrs - set(fields)}
@@ -59,7 +59,7 @@ def test_compliant_standard(cosmology_cls, standard_attrs, standard_meths):
         frozen=True,
     )
 
-    cosmo = StandardCosmology()
+    cosmo = ExampleStandardCosmology()
 
     # Check Base and Background
     assert isinstance(cosmo, CosmologyAPI)
@@ -79,12 +79,12 @@ def test_compliant_standard(cosmology_cls, standard_attrs, standard_meths):
     assert isinstance(cosmo, HasTcmb)
 
     # Full Standard Cosmology
-    assert isinstance(cosmo, StandardCosmologyAPI)
+    assert isinstance(cosmo, StandardCosmology)
 
 
 def test_fixture(standardcosmo):
     """
     Test that the ``standardcosmo`` fixture is a
-    `cosmology.api.StandardCosmologyAPI`.
+    `cosmology.api.StandardCosmology`.
     """
-    assert isinstance(standardcosmo, StandardCosmologyAPI)
+    assert isinstance(standardcosmo, StandardCosmology)


### PR DESCRIPTION
@ntessore, what do you think of renaming the other classes ending with `API`?

Also, given our discussion of future extensions, the non-`StandardCosmology` will have the same API, so it doesn't make much sense to call it `Standard`. What about renaming it to `CoreCosmology` as this is the core API and has all the components for what many refer to as "core" cosmology (no weird dark energy, etc.) 

## PR Checklist

- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
