### PR TITLE
Public scope components

### DIFF
--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -1,15 +1,6 @@
 """The Cosmology API standard."""
 
-from cosmology.api._components import (
-    HasBaryonComponent,
-    HasDarkEnergyComponent,
-    HasDarkMatterComponent,
-    HasGlobalCurvatureComponent,
-    HasMatterComponent,
-    HasNeutrinoComponent,
-    HasPhotonComponent,
-    HasTotalComponent,
-)
+from cosmology.api import compat, component
 from cosmology.api._constants import CosmologyConstantsNamespace
 from cosmology.api._core import Cosmology
 from cosmology.api._distances import HasDistanceMeasures
@@ -22,18 +13,13 @@ from cosmology.api.compat import (
 )
 
 __all__ = [
+    # Modules
+    "compat",
+    "component",
+    # Classes
     "Cosmology",
     "HasDistanceMeasures",
     "StandardCosmology",
-    # components
-    "HasTotalComponent",
-    "HasGlobalCurvatureComponent",
-    "HasMatterComponent",
-    "HasBaryonComponent",
-    "HasNeutrinoComponent",
-    "HasDarkEnergyComponent",
-    "HasDarkMatterComponent",
-    "HasPhotonComponent",
     # parametrizations
     "HasCriticalDensity",
     "HasHubbleParameter",

--- a/src/cosmology/api/__init__.py
+++ b/src/cosmology/api/__init__.py
@@ -7,10 +7,6 @@ from cosmology.api._distances import HasDistanceMeasures
 from cosmology.api._extras import HasCriticalDensity, HasHubbleParameter
 from cosmology.api._namespace import CosmologyNamespace
 from cosmology.api._standard import StandardCosmology
-from cosmology.api.compat import (
-    CosmologyWrapper,
-    StandardCosmologyWrapper,
-)
 
 __all__ = [
     # Modules
@@ -23,9 +19,6 @@ __all__ = [
     # parametrizations
     "HasCriticalDensity",
     "HasHubbleParameter",
-    # wrappers
-    "CosmologyWrapper",
-    "StandardCosmologyWrapper",
     # Namespaces
     "CosmologyNamespace",
     "CosmologyConstantsNamespace",

--- a/src/cosmology/api/_standard.py
+++ b/src/cosmology/api/_standard.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 from cosmology.api._array_api import ArrayT
-from cosmology.api._components import (
+from cosmology.api._distances import HasDistanceMeasures
+from cosmology.api._extras import HasCriticalDensity, HasHubbleParameter
+from cosmology.api.component import (
     HasBaryonComponent,
     HasDarkEnergyComponent,
     HasDarkMatterComponent,
@@ -15,8 +17,6 @@ from cosmology.api._components import (
     HasPhotonComponent,
     HasTotalComponent,
 )
-from cosmology.api._distances import HasDistanceMeasures
-from cosmology.api._extras import HasCriticalDensity, HasHubbleParameter
 
 __all__: list[str] = []
 

--- a/src/cosmology/api/component.py
+++ b/src/cosmology/api/component.py
@@ -7,7 +7,16 @@ from typing import Protocol
 from cosmology.api._array_api import ArrayT
 from cosmology.api._core import Cosmology
 
-__all__: list[str] = []
+__all__ = [
+    "HasTotalComponent",
+    "HasGlobalCurvatureComponent",
+    "HasMatterComponent",
+    "HasBaryonComponent",
+    "HasNeutrinoComponent",
+    "HasDarkEnergyComponent",
+    "HasDarkMatterComponent",
+    "HasPhotonComponent",
+]
 
 
 class HasTotalComponent(Cosmology[ArrayT], Protocol):


### PR DESCRIPTION
Following #38

> On a related note, should we public scope cosmology.api.components, and move all the HasXComponents
from cosmology.api.__all__ to cosmology.api.components.__all__.

This is a balance between a shallow and deep namespace. On the one hand, a shallow namespace is easier to introspect, but it doesn't provide any logical organization. This PR is to move where the components and wrappers are publicly scoped.

## PR Checklist

- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
